### PR TITLE
Localization fix.

### DIFF
--- a/Content/Calamity/Items/Summons/ABombInMyNation.cs
+++ b/Content/Calamity/Items/Summons/ABombInMyNation.cs
@@ -13,7 +13,6 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     {
         public override string Texture => "CalamityMod/Items/SummonItems/Abombination";
         public override int NPCType => ModContent.NPCType<PlaguebringerGoliath>();
-        public override string NPCName => "Plaguebringer Goliath";
         public override void AddRecipes()
         {
             Recipe.Create(Type).AddIngredient<Abombination>().AddTile(TileID.WorkBenches).Register();

--- a/Content/Calamity/Items/Summons/AbandonedRemote.cs
+++ b/Content/Calamity/Items/Summons/AbandonedRemote.cs
@@ -16,7 +16,6 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     public class AbandonedRemote : BaseSummon
     {
         public override int NPCType => ModContent.NPCType<ArmoredDiggerHead>();
-        public override string NPCName => "Armored Digger";
         public override void AddRecipes()
         {
         }

--- a/Content/Calamity/Items/Summons/AstrumCor.cs
+++ b/Content/Calamity/Items/Summons/AstrumCor.cs
@@ -16,7 +16,6 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     public class AstrumCor : BaseSummon
     {
         public override int NPCType => ModContent.NPCType<AstrumDeusHead>();
-        public override string NPCName => "Astrum Deus";
         public override void AddRecipes()
         {
             Recipe.Create(Type).AddIngredient<Starcore>().AddTile(TileID.WorkBenches).DisableDecraft().Register();

--- a/Content/Calamity/Items/Summons/BirbPheromones.cs
+++ b/Content/Calamity/Items/Summons/BirbPheromones.cs
@@ -13,7 +13,6 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     {
         public override string Texture => "CalamityMod/Items/SummonItems/ExoticPheromones";
         public override int NPCType => ModContent.NPCType<Bumblefuck>();
-        public override string NPCName => "Dragonfolly";
         public override void AddRecipes()
         {
             Recipe.Create(Type).AddIngredient<ExoticPheromones>().AddTile(TileID.WorkBenches).Register();

--- a/Content/Calamity/Items/Summons/BlightedEye.cs
+++ b/Content/Calamity/Items/Summons/BlightedEye.cs
@@ -13,7 +13,6 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     {
         public override string Texture => "CalamityMod/Items/SummonItems/EyeofDesolation";
         public override int NPCType => ModContent.NPCType<CalamitasClone>();
-        public override string NPCName => "Calamitas Clone";
         public override void AddRecipes()
         {
             Recipe.Create(Type).AddIngredient<EyeofDesolation>().AddTile(TileID.WorkBenches).Register();

--- a/Content/Calamity/Items/Summons/BloodyWorm.cs
+++ b/Content/Calamity/Items/Summons/BloodyWorm.cs
@@ -13,7 +13,6 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     {
         public override string Texture => "CalamityMod/Items/SummonItems/BloodwormItem";
         public override int NPCType => ModContent.NPCType<OldDuke>();
-        public override string NPCName => "Old Duke";
         public override void AddRecipes()
         {
             Recipe.Create(Type).AddIngredient<BloodwormItem>().AddTile(TileID.WorkBenches).Register();

--- a/Content/Calamity/Items/Summons/ChunkyStardust.cs
+++ b/Content/Calamity/Items/Summons/ChunkyStardust.cs
@@ -13,7 +13,6 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     {
         public override string Texture => "CalamityMod/Items/SummonItems/AstralChunk";
         public override int NPCType => ModContent.NPCType<AstrumAureus>();
-        public override string NPCName => "Astrum Aureus";
         public override void AddRecipes()
         {
             Recipe.Create(Type).AddIngredient<AstralChunk>().AddTile(TileID.WorkBenches).Register();

--- a/Content/Calamity/Items/Summons/ClamPearl.cs
+++ b/Content/Calamity/Items/Summons/ClamPearl.cs
@@ -14,7 +14,6 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     public class ClamPearl : BaseSummon
     {
         public override int NPCType => ModContent.NPCType<GiantClam>();
-        public override string NPCName => "Giant Clam";
         public override void AddRecipes()
         {
             Recipe.Create(Type).AddIngredient<SeaPrism>(20).AddIngredient<PearlShard>(5).AddTile(TileID.Anvils).Register();

--- a/Content/Calamity/Items/Summons/ColossalTentacle.cs
+++ b/Content/Calamity/Items/Summons/ColossalTentacle.cs
@@ -13,7 +13,6 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     public class ColossalTentacle : BaseSummon
     {
         public override int NPCType => ModContent.NPCType<ColossalSquid>();
-        public override string NPCName => "Colossal Squid";
         public override void AddRecipes()
         {
         }

--- a/Content/Calamity/Items/Summons/CryingKey.cs
+++ b/Content/Calamity/Items/Summons/CryingKey.cs
@@ -13,7 +13,6 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     {
         public override string Texture => "CalamityMod/Items/SummonItems/CryoKey";
         public override int NPCType => ModContent.NPCType<Cryogen>();
-        public override string NPCName => "Cryogen";
         public override void AddRecipes()
         {
             Recipe.Create(Type).AddIngredient<CryoKey>().AddTile(TileID.WorkBenches).Register();

--- a/Content/Calamity/Items/Summons/DeepseaProteinShake.cs
+++ b/Content/Calamity/Items/Summons/DeepseaProteinShake.cs
@@ -12,7 +12,6 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     public class DeepseaProteinShake : BaseSummon
     {
         public override int NPCType => ModContent.NPCType<ReaperShark>();
-        public override string NPCName => "Reaper Shark";
         public override void AddRecipes()
         {
         }

--- a/Content/Calamity/Items/Summons/DefiledCore.cs
+++ b/Content/Calamity/Items/Summons/DefiledCore.cs
@@ -13,7 +13,6 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     {
         public override string Texture => "CalamityMod/Items/SummonItems/ProfanedCore";
         public override int NPCType => ModContent.NPCType<Providence>();
-        public override string NPCName => "Providence";
         public override void AddRecipes()
         {
             Recipe.Create(Type).AddIngredient<ProfanedCore>().AddTile(TileID.WorkBenches).Register();

--- a/Content/Calamity/Items/Summons/DefiledShard.cs
+++ b/Content/Calamity/Items/Summons/DefiledShard.cs
@@ -4,6 +4,7 @@ using Fargowiltas.Items.Summons;
 using FargowiltasCrossmod.Core;
 using Terraria;
 using Terraria.ID;
+using Terraria.Localization;
 using Terraria.ModLoader;
 
 namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
@@ -13,7 +14,7 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     {
         public override string Texture => "CalamityMod/Items/SummonItems/ProfanedShard";
         public override int NPCType => ModContent.NPCType<ProfanedGuardianCommander>();
-        public override string NPCName => "Profaned Guardians";
+        public override string NPCName => Language.GetTextValue("Mods.CalamityMod.BossChecklistIntegration.ProfanedGuardians.EntryName");
         public override void AddRecipes()
         {
             Recipe.Create(Type).AddIngredient<ProfanedShard>().AddTile(TileID.WorkBenches).Register();

--- a/Content/Calamity/Items/Summons/DragonEgg.cs
+++ b/Content/Calamity/Items/Summons/DragonEgg.cs
@@ -13,7 +13,6 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     {
         public override string Texture => "CalamityMod/Items/SummonItems/YharonEgg";
         public override int NPCType => ModContent.NPCType<Yharon>();
-        public override string NPCName => "Yharon";
         public override void AddRecipes()
         {
             Recipe.Create(Type).AddIngredient<YharonEgg>().AddTile(TileID.WorkBenches).Register();

--- a/Content/Calamity/Items/Summons/EyeofExtinction.cs
+++ b/Content/Calamity/Items/Summons/EyeofExtinction.cs
@@ -23,7 +23,6 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     public class EyeofExtinction : BaseSummon
     {
         public override int NPCType => ModContent.NPCType<SupremeCalamitas>();
-        public override string NPCName => "Supreme Calamitas";
         public override void AddRecipes()
         {
             Recipe.Create(Type).AddIngredient<AshesofCalamity>(10).AddIngredient<AuricBar>(4).AddTile(TileID.WorkBenches).Register();

--- a/Content/Calamity/Items/Summons/FriedDoll.cs
+++ b/Content/Calamity/Items/Summons/FriedDoll.cs
@@ -13,7 +13,6 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     {
         public override string Texture => "CalamityMod/Items/SummonItems/CharredIdol";
         public override int NPCType => ModContent.NPCType<BrimstoneElemental>();
-        public override string NPCName => "Brimstone Elemental";
         public override void AddRecipes()
         {
             Recipe.Create(Type).AddIngredient<CharredIdol>().AddTile(TileID.WorkBenches).Register();

--- a/Content/Calamity/Items/Summons/HiveTumor.cs
+++ b/Content/Calamity/Items/Summons/HiveTumor.cs
@@ -13,7 +13,6 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     {
         public override string Texture => "CalamityMod/Items/SummonItems/Teratoma";
         public override int NPCType => ModContent.NPCType<HiveMind>();
-        public override string NPCName => "Hive Mind";
         public override void AddRecipes()
         {
             Recipe.Create(Type).AddIngredient<Teratoma>().AddTile(TileID.WorkBenches).Register();

--- a/Content/Calamity/Items/Summons/LetterofKos.cs
+++ b/Content/Calamity/Items/Summons/LetterofKos.cs
@@ -12,7 +12,6 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     public class LetterofKos : BaseSummon
     {
         public override int NPCType => ModContent.NPCType<Signus>();
-        public override string NPCName => "Signus";
         public override void AddRecipes()
         {
             Recipe.Create(Type).AddIngredient<RuneofKos>().AddTile(TileID.WorkBenches).Register();

--- a/Content/Calamity/Items/Summons/MaulerSkull.cs
+++ b/Content/Calamity/Items/Summons/MaulerSkull.cs
@@ -15,7 +15,6 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     public class MaulerSkull : BaseSummon
     {
         public override int NPCType => ModContent.NPCType<Mauler>();
-        public override string NPCName => "Mauler";
         public override void AddRecipes()
         {
             Recipe.Create(Type).AddIngredient<CorrodedFossil>(10).AddIngredient<NuclearChunk>().AddTile(TileID.Anvils).Register();

--- a/Content/Calamity/Items/Summons/MedallionoftheDesert.cs
+++ b/Content/Calamity/Items/Summons/MedallionoftheDesert.cs
@@ -17,7 +17,6 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     {
         public override string Texture => "CalamityMod/Items/SummonItems/DesertMedallion";
         public override int NPCType => ModContent.NPCType<DesertScourgeHead>();
-        public override string NPCName => "Desert Scourge";
         public override void AddRecipes()
         {
             Recipe.Create(Type).AddIngredient<DesertMedallion>().AddTile(TileID.WorkBenches).Register();

--- a/Content/Calamity/Items/Summons/MurkySludge.cs
+++ b/Content/Calamity/Items/Summons/MurkySludge.cs
@@ -13,7 +13,6 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     {
         public override string Texture => "CalamityMod/Items/SummonItems/OverloadedSludge";
         public override int NPCType => ModContent.NPCType<SlimeGodCore>();
-        public override string NPCName => "Slime God";
         public override void AddRecipes()
         {
             Recipe.Create(Type).AddIngredient<OverloadedSludge>().AddTile(TileID.WorkBenches).Register();

--- a/Content/Calamity/Items/Summons/NoisyWhistle.cs
+++ b/Content/Calamity/Items/Summons/NoisyWhistle.cs
@@ -19,7 +19,6 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     {
         public override string Texture => "CalamityMod/Items/SummonItems/DeathWhistle";
         public override int NPCType => ModContent.NPCType<RavagerBody>();
-        public override string NPCName => "Ravager";
         public override void AddRecipes()
         {
             Recipe.Create(Type).AddIngredient<DeathWhistle>().AddTile(TileID.WorkBenches).Register();

--- a/Content/Calamity/Items/Summons/NuclearChunk.cs
+++ b/Content/Calamity/Items/Summons/NuclearChunk.cs
@@ -12,7 +12,6 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     public class NuclearChunk : BaseSummon
     {
         public override int NPCType => ModContent.NPCType<NuclearTerror>();
-        public override string NPCName => "Nuclear Terror";
         public override void AddRecipes()
         {
         }

--- a/Content/Calamity/Items/Summons/OphiocordycipitaceaeSprout.cs
+++ b/Content/Calamity/Items/Summons/OphiocordycipitaceaeSprout.cs
@@ -13,7 +13,6 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     {
         public override string Texture => "CalamityMod/Items/SummonItems/DecapoditaSprout";
         public override int NPCType => ModContent.NPCType<Crabulon>();
-        public override string NPCName => "Crabulon";
         public override void AddRecipes()
         {
             Recipe.Create(Type).AddIngredient<DecapoditaSprout>().AddTile(TileID.WorkBenches).Register();

--- a/Content/Calamity/Items/Summons/PlaguedWalkieTalkie.cs
+++ b/Content/Calamity/Items/Summons/PlaguedWalkieTalkie.cs
@@ -15,7 +15,6 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     public class PlaguedWalkieTalkie : BaseSummon
     {
         public override int NPCType => ModContent.NPCType<PlaguebringerMiniboss>();
-        public override string NPCName => "Plaguebringer";
         public override void AddRecipes()
         {
         }

--- a/Content/Calamity/Items/Summons/PolterplasmicBeacon.cs
+++ b/Content/Calamity/Items/Summons/PolterplasmicBeacon.cs
@@ -13,7 +13,6 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     {
         public override string Texture => "CalamityMod/Items/SummonItems/NecroplasmicBeacon";
         public override int NPCType => ModContent.NPCType<Polterghast>();
-        public override string NPCName => "Polterghast";
         public override void AddRecipes()
         {
             Recipe.Create(Type).AddIngredient<NecroplasmicBeacon>().AddTile(TileID.WorkBenches).Register();

--- a/Content/Calamity/Items/Summons/PortableCodebreaker.cs
+++ b/Content/Calamity/Items/Summons/PortableCodebreaker.cs
@@ -15,7 +15,6 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     {
         //public override string Texture => "CalamityMod/Items/Materials/ExoPrism";
         public override int NPCType => ModContent.NPCType<Draedon>();
-        public override string NPCName => "Draedon";
         public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
         {
             // Everything burns if there's more than one Draedon/Exo Mech pair.

--- a/Content/Calamity/Items/Summons/QuakeIdol.cs
+++ b/Content/Calamity/Items/Summons/QuakeIdol.cs
@@ -11,7 +11,6 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     public class QuakeIdol : BaseSummon
     {
         public override int NPCType => ModContent.NPCType<Horse>();
-        public override string NPCName => "Earth Elemental";
         public override void AddRecipes()
         {
         }

--- a/Content/Calamity/Items/Summons/RedStainedWormFood.cs
+++ b/Content/Calamity/Items/Summons/RedStainedWormFood.cs
@@ -13,7 +13,6 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     {
         public override string Texture => "CalamityMod/Items/SummonItems/BloodyWormFood";
         public override int NPCType => ModContent.NPCType<PerforatorHive>();
-        public override string NPCName => "Perforator Hive";
         public override void AddRecipes()
         {
             Recipe.Create(Type).AddIngredient<BloodyWormFood>().AddTile(TileID.WorkBenches).Register();

--- a/Content/Calamity/Items/Summons/RiftofKos.cs
+++ b/Content/Calamity/Items/Summons/RiftofKos.cs
@@ -12,7 +12,6 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     public class RiftofKos : BaseSummon
     {
         public override int NPCType => ModContent.NPCType<CeaselessVoid>();
-        public override string NPCName => "Ceaseless Void";
         public override void AddRecipes()
         {
             Recipe.Create(Type).AddIngredient<RuneofKos>().AddTile(TileID.WorkBenches).Register();

--- a/Content/Calamity/Items/Summons/SeeFood.cs
+++ b/Content/Calamity/Items/Summons/SeeFood.cs
@@ -16,7 +16,6 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     {
         public override string Texture => "CalamityMod/Items/SummonItems/Seafood";
         public override int NPCType => ModContent.NPCType<AquaticScourgeHead>();
-        public override string NPCName => "Aquatic Scourge";
         public override void AddRecipes()
         {
             Recipe.Create(Type).AddIngredient<Seafood>().AddTile(TileID.WorkBenches).Register();

--- a/Content/Calamity/Items/Summons/SirensPearl.cs
+++ b/Content/Calamity/Items/Summons/SirensPearl.cs
@@ -4,6 +4,7 @@ using Fargowiltas.Items.Summons;
 using FargowiltasCrossmod.Core;
 using Terraria;
 using Terraria.ID;
+using Terraria.Localization;
 using Terraria.ModLoader;
 
 namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
@@ -12,7 +13,7 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     public class SirensPearl : BaseSummon
     {
         public override int NPCType => ModContent.NPCType<Anahita>();
-        public override string NPCName => "Anahita and the Leviathan";
+        public override string NPCName => Language.GetTextValue("Mods.CalamityMod.BossChecklistIntegration.Leviathan.EntryName");
         public override void AddRecipes()
         {
             Recipe.Create(Type).AddIngredient(ItemID.WhitePearl).AddIngredient<PerennialBar>(5).AddTile(TileID.WorkBenches).Register();

--- a/Content/Calamity/Items/Summons/SomeKindofSpaceWorm.cs
+++ b/Content/Calamity/Items/Summons/SomeKindofSpaceWorm.cs
@@ -16,7 +16,6 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     {
         public override string Texture => "CalamityMod/Items/SummonItems/CosmicWorm";
         public override int NPCType => ModContent.NPCType<DevourerofGodsHead>();
-        public override string NPCName => "Devourer of Gods";
         public override void AddRecipes()
         {
             Recipe.Create(Type).AddIngredient<CosmicWorm>().AddTile(TileID.WorkBenches).Register();

--- a/Content/Calamity/Items/Summons/StormIdol.cs
+++ b/Content/Calamity/Items/Summons/StormIdol.cs
@@ -15,7 +15,6 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     {
         //FUCK you fabsol for making me type this
         public override int NPCType => ModContent.NPCType<ThiccWaifu>();
-        public override string NPCName => "Cloud Elemental";
         public override void AddRecipes()
         {
         }

--- a/Content/Calamity/Items/Summons/SulphurBearTrap.cs
+++ b/Content/Calamity/Items/Summons/SulphurBearTrap.cs
@@ -14,7 +14,6 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     public class SulphurBearTrap : BaseSummon
     {
         public override int NPCType => ModContent.NPCType<CragmawMire>();
-        public override string NPCName => "Cragmaw Mire";
         public override void AddRecipes()
         {
             Recipe.Create(Type).AddIngredient<CorrodedFossil>(15).AddRecipeGroup(RecipeGroupID.IronBar, 5).AddTile(TileID.Anvils).Register();

--- a/Content/Calamity/Items/Summons/WormFoodofKos.cs
+++ b/Content/Calamity/Items/Summons/WormFoodofKos.cs
@@ -15,7 +15,6 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     public class WormFoodofKos : BaseSummon
     {
         public override int NPCType => ModContent.NPCType<StormWeaverHead>();
-        public override string NPCName => "Storm Weaver";
         public override void AddRecipes()
         {
             Recipe.Create(Type).AddIngredient<RuneofKos>().AddTile(TileID.WorkBenches).Register();

--- a/Content/Calamity/Items/Summons/WyrmTablet.cs
+++ b/Content/Calamity/Items/Summons/WyrmTablet.cs
@@ -18,7 +18,6 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Summons
     public class WyrmTablet : BaseSummon
     {
         public override int NPCType => ModContent.NPCType<EidolonWyrmHead>();
-        public override string NPCName => "Eidolon Wyrm";
         public override void AddRecipes()
         {
         }

--- a/Content/Common/Bosses/Mutant/MutantDLC.cs
+++ b/Content/Common/Bosses/Mutant/MutantDLC.cs
@@ -22,6 +22,7 @@ using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.Audio;
 using Terraria.ID;
+using Terraria.Localization;
 using Terraria.ModLoader;
 using Terraria.ModLoader.IO;
 
@@ -409,7 +410,7 @@ namespace FargowiltasCrossmod.Content.Common.Bosses.Mutant
                         npc.ai[3] = 0;
                         npc.netUpdate = true;
                         FargoSoulsUtil.ClearHostileProjectiles(1, npc.whoAmI);
-                        EdgyBossText("Time to stop playing around.");
+                        EdgyBossText(Language.GetTextValue("Mods.FargowiltasCrossmod.NPCs.MutantGFBText.QuoteP2"));
                     }
                     return true;
                 }
@@ -1413,7 +1414,7 @@ namespace FargowiltasCrossmod.Content.Common.Bosses.Mutant
                     else
                         npc.localAI[1] = 5;
 
-                    EdgyBossText("The world is trembling..");
+                    EdgyBossText(Language.GetTextValue("Mods.FargowiltasCrossmod.NPCs.MutantGFBText.QuoteDoG"));
                 }
 
                 if (++npc.ai[1] > 60)

--- a/Content/Common/ModSwapperUI.cs
+++ b/Content/Common/ModSwapperUI.cs
@@ -8,6 +8,7 @@ using Terraria;
 using Terraria.GameContent.UI.Elements;
 using Terraria.ModLoader;
 using Terraria.UI;
+using Terraria.Localization;
 
 namespace FargowiltasCrossmod.Content.Common
 {
@@ -93,7 +94,7 @@ namespace FargowiltasCrossmod.Content.Common
                 int currentShop = DevianttGlobalNPC.currentShop;
                 if (currentShop == 0)
                 {
-                    (listeningElement as UITextPanel<string>).SetText("Vanilla");
+                    (listeningElement as UITextPanel<string>).SetText(Language.GetTextValue("Mods.FargowiltasCrossmod.NPCs.ShopModSwapper.Vanilla"));
                 }
                 else
                 {

--- a/Core/Calamity/CalDLCSets.cs
+++ b/Core/Calamity/CalDLCSets.cs
@@ -29,6 +29,8 @@ using CalamityMod.Items.Weapons.DraedonsArsenal;
 using CalamityMod.Items.Weapons.Magic;
 using CalamityMod.Items.Weapons.Melee;
 using CalamityMod.Items.Weapons.Ranged;
+using CalamityMod.Items.Tools;
+using CalamityMod.Items.Weapons.Typeless;
 using Fargowiltas;
 using CalamityMod.Items.Placeables.Furniture;
 using FargowiltasSouls.Content.Bosses.TrojanSquirrel;

--- a/Core/Calamity/Globals/CalDLCItemChanges.cs
+++ b/Core/Calamity/Globals/CalDLCItemChanges.cs
@@ -269,10 +269,11 @@ namespace FargowiltasCrossmod.Core.Calamity.Globals
 
             if (WorldSavingSystem.EternityMode)
             {
+                string notConsumable = Language.GetTextValue("Mods.FargowiltasCrossmod.Items.NotConsumable");
                 for (int i = 0; i < tooltips.Count; i++)
                 {
-                    tooltips[i].Text = tooltips[i].Text.Replace("\nNot consumable", "");
-                    tooltips[i].Text = tooltips[i].Text.Replace("Not consumable", "");
+                    tooltips[i].Text = tooltips[i].Text.Replace("\n" + notConsumable, "");
+                    tooltips[i].Text = tooltips[i].Text.Replace(notConsumable, "");
                 }
             }
             for (int i = 0; i < tooltips.Count; i++)

--- a/Core/Calamity/Globals/CalDLCNPCChanges.cs
+++ b/Core/Calamity/Globals/CalDLCNPCChanges.cs
@@ -90,6 +90,7 @@ using System.Collections.Generic;
 using Terraria;
 using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
+using Terraria.Localization;
 using Terraria.ModLoader;
 
 namespace FargowiltasCrossmod.Core.Calamity.Globals
@@ -921,7 +922,7 @@ namespace FargowiltasCrossmod.Core.Calamity.Globals
                 });
                 npcLoot.DefineConditionalDropSet(If(() => !death && (Condition.Hardmode.IsMet()), () => !death && (Condition.Hardmode.IsMet()), "")).Add(ItemID.CursedFlame, 1, 2, 5);
                 npcLoot.DefineConditionalDropSet(If(() => death && (Condition.Hardmode.IsMet()), () => death && (Condition.Hardmode.IsMet()), "")).Add(ItemID.CursedFlame, 1, 6, 15);
-                npcLoot.DefineConditionalDropSet(If(() => death && (Condition.Hardmode.IsMet()), () => death && (Condition.Hardmode.IsMet()), "In Death Mode")).Add(ItemID.SoulofNight, 1, 4, 8);
+                npcLoot.DefineConditionalDropSet(If(() => death && (Condition.Hardmode.IsMet()), () => death && (Condition.Hardmode.IsMet()), Language.GetTextValue("Mods.FargowiltasCrossmod.Conditions.InDeathMod"))).Add(ItemID.SoulofNight, 1, 4, 8);
             }
             if (npc.type == NPCID.SandElemental)
             {
@@ -1079,7 +1080,8 @@ namespace FargowiltasCrossmod.Core.Calamity.Globals
             }
             if (doDeviText && Main.netMode != NetmodeID.Server)
             {
-                Main.NewText("A new item has been unlocked in Deviantt's shop!", Color.HotPink);
+                string seller = Language.GetTextValue($"Mods.Fargowiltas.NPCs.Deviantt.DisplayName");
+                Main.NewText(Language.GetTextValue("Mods.Fargowiltas.MessageInfo.NewItemUnlocked", seller), Color.HotPink);
             }
             #endregion
             //the thing
@@ -1639,12 +1641,12 @@ namespace FargowiltasCrossmod.Core.Calamity.Globals
             {
                 if (PermafrostDefeatLine == 1)
                 {
-                    chat = "You clearly possess great skill! My thanks to you for freeing me, and providing an opportunity to defrost my fighting abilities.";
+                    chat = Language.GetTextValue("Mods.FargowiltasCrossmod.NPCs.PermafrostChat.Defeat1");
                     PermafrostDefeatLine = 0;
                 }
                 if (PermafrostDefeatLine == 2)
                 {
-                    chat = "Aah, a good round of sparring. I need the exercise, so thanks for that.";
+                    chat = Language.GetTextValue("Mods.FargowiltasCrossmod.NPCs.PermafrostChat.Defeat2");
                     PermafrostDefeatLine = 0;
                 }
             }
@@ -1653,10 +1655,10 @@ namespace FargowiltasCrossmod.Core.Calamity.Globals
         {
 
 
-            Condition killedCragmaw = new Condition("Kill a Cragmaw Mire", () => CalDLCCompatibilityMisc.DownedCragmaw);
-            Condition killedMauler = new Condition("Kill a Mauler", () => CalDLCCompatibilityMisc.DownedMauler);
-            Condition killedNuclear = new Condition("Kill a Nuclear Terror", () => CalDLCCompatibilityMisc.DownedNuclear);
-            Condition killedGSS = new Condition("Kill a Great Sand Shark", () => CalDLCCompatibilityMisc.DownedGSS);
+            Condition killedCragmaw = new Condition("Mods.FargowiltasCrossmod.Conditions.CragmawMireDowned", () => CalDLCCompatibilityMisc.DownedCragmaw);
+            Condition killedMauler = new Condition("Mods.FargowiltasCrossmod.Conditions.CragmawMireDowned", () => CalDLCCompatibilityMisc.DownedMauler);
+            Condition killedNuclear = new Condition("Mods.FargowiltasCrossmod.Conditions.CragmawMireDowned", () => CalDLCCompatibilityMisc.DownedNuclear);
+            Condition killedGSS = new Condition("Mods.FargowiltasCrossmod.Conditions.CragmawMireDowned", () => CalDLCCompatibilityMisc.DownedGSS);
             if (shop.NpcType == ModContent.NPCType<Abominationn>())
             {
                 shop.Add(new Item(ModContent.ItemType<SulphurBearTrap>()) { shopCustomPrice = Item.buyPrice(gold: 10) }, killedCragmaw);

--- a/Core/Calamity/Systems/CalDLCDetours.cs
+++ b/Core/Calamity/Systems/CalDLCDetours.cs
@@ -628,17 +628,17 @@ namespace FargowiltasCrossmod.Core.Calamity.Systems
             {
                 if (phase == BossRushDialoguePhase.StartRepeat && currLine == 0)
                 {
-                    Main.NewText("Let's get started.", Color.Teal);
+                    Main.NewText(Language.GetTextValue("Mods.FargowiltasCrossmod.BossRushDialogue.Start"), Color.Teal);
                     BossRushEvent.BossRushStage = 1;
                 }
                 if (phase == BossRushDialoguePhase.TierOneComplete)
                 {
                     if (currLine == 0)
-                        Main.NewText("This is boring.", Color.Teal);
+                        Main.NewText(Language.GetTextValue("Mods.FargowiltasCrossmod.BossRushDialogue.EndP1_1"), Color.Teal);
                     //if (currLine == 1)
                         
                     if (currLine == 2)
-                        Main.NewText("Let's cut to the chase.", Color.Teal);
+                        Main.NewText(Language.GetTextValue("Mods.FargowiltasCrossmod.BossRushDialogue.EndP1_2"), Color.Teal);
                 }
                 BossRushDialogueSystem.CurrentDialogueDelay = 60;
                 BossRushDialogueSystem.currentSequenceIndex += 1;

--- a/Core/Calamity/Systems/CalDLCWorldUpdatingSystem.cs
+++ b/Core/Calamity/Systems/CalDLCWorldUpdatingSystem.cs
@@ -9,6 +9,7 @@ using System;
 using Terraria;
 using Terraria.DataStructures;
 using Terraria.ID;
+using Terraria.Localization;
 using Terraria.ModLoader;
 
 namespace FargowiltasCrossmod.Core.Calamity.Systems
@@ -64,7 +65,7 @@ namespace FargowiltasCrossmod.Core.Calamity.Systems
                     {
                         WorldSavingSystem.EternityMode = false;
                         WorldSavingSystem.ShouldBeEternityMode = false;
-                        Main.NewText("[c/00ffee:Eternity Mode] disabled by [c/9c0000:Infernum Mode].");
+                        Main.NewText(Language.GetTextValue("Mods.FargowiltasCrossmod.EmodeBannedByInfernum"));
                         if (Main.netMode != NetmodeID.SinglePlayer)
                             PacketManager.SendPacket<EternityRevPacket>();
                     }

--- a/Core/Common/Globals/DevianttGlobalNPC.cs
+++ b/Core/Common/Globals/DevianttGlobalNPC.cs
@@ -13,6 +13,7 @@ using Fargowiltas.Items.Summons.Deviantt;
 using Fargowiltas.Items.Tiles;
 using Fargowiltas;
 using static Terraria.ModLoader.ModContent;
+using Terraria.Localization;
 
 namespace FargowiltasCrossmod.Core.Common.Globals
 {
@@ -36,16 +37,16 @@ namespace FargowiltasCrossmod.Core.Common.Globals
         {
             if (!ModCompatibility.Calamity.Loaded)
                 return;
-            NPCShop shop = new(ModContent.NPCType<Deviantt>(), "Calamity");
+            NPCShop shop = new(ModContent.NPCType<Deviantt>(), Language.GetTextValue("Mods.FargowiltasCrossmod.NPCs.ShopModSwapper.Calamity"));
 
-            Condition killedClam = new Condition("After killing a Giant Clam", () => CalDLCCompatibilityMisc.DownedClam);
-            Condition killedPlaguebringerMini = new Condition("After killing a Plaguebringer", () => CalDLCWorldSavingSystem.downedMiniPlaguebringer);
-            Condition killedReaperShark = new Condition("After killing a Reaper Shark", () => CalDLCWorldSavingSystem.downedReaperShark);
-            Condition killedColossalSquid = new Condition("After killing a Colossal Squid", () => CalDLCWorldSavingSystem.downedColossalSquid);
-            Condition killedEidolonWyrm = new Condition("After killing an Eidolon Wyrm", () => CalDLCWorldSavingSystem.downedEidolonWyrm);
-            Condition killedCloudElemental = new Condition("After killing a Cloud Elemental", () => CalDLCWorldSavingSystem.downedCloudElemental);
-            Condition killedEarthElemental = new Condition("After killing an Earth Elemental", () => CalDLCWorldSavingSystem.downedEarthElemental);
-            Condition killedArmoredDigger = new Condition("After killing an Armored Digger", () => CalDLCWorldSavingSystem.downedArmoredDigger);
+            Condition killedClam = new Condition("Mods.FargowiltasCrossmod.Conditions.GiantClamDowned", () => CalDLCCompatibilityMisc.DownedClam);
+            Condition killedPlaguebringerMini = new Condition("Mods.FargowiltasCrossmod.Conditions.PlaguebringerDowned", () => CalDLCWorldSavingSystem.downedMiniPlaguebringer);
+            Condition killedReaperShark = new Condition("Mods.FargowiltasCrossmod.Conditions.ReaperSharkDowned", () => CalDLCWorldSavingSystem.downedReaperShark);
+            Condition killedColossalSquid = new Condition("Mods.FargowiltasCrossmod.Conditions.ColossalSquidDowned", () => CalDLCWorldSavingSystem.downedColossalSquid);
+            Condition killedEidolonWyrm = new Condition("Mods.FargowiltasCrossmod.Conditions.EidolonWyrmDowned", () => CalDLCWorldSavingSystem.downedEidolonWyrm);
+            Condition killedCloudElemental = new Condition("Mods.FargowiltasCrossmod.Conditions.CloudElementalDowned", () => CalDLCWorldSavingSystem.downedCloudElemental);
+            Condition killedEarthElemental = new Condition("Mods.FargowiltasCrossmod.Conditions.EarthElementalDowned", () => CalDLCWorldSavingSystem.downedEarthElemental);
+            Condition killedArmoredDigger = new Condition("Mods.FargowiltasCrossmod.Conditions.ArmoredDiggerDowned", () => CalDLCWorldSavingSystem.downedArmoredDigger);
 
             shop.Add(new Item(ModContent.ItemType<ClamPearl>()) { shopCustomPrice = Item.buyPrice(gold: 5) }, killedClam);
             shop.Add(new Item(ModContent.ItemType<AbandonedRemote>()) { shopCustomPrice = Item.buyPrice(gold: 10) }, killedArmoredDigger);

--- a/Localization/en-US/Mods.FargowiltasCrossmod.Conditions.hjson
+++ b/Localization/en-US/Mods.FargowiltasCrossmod.Conditions.hjson
@@ -1,0 +1,13 @@
+GiantClamDowned: After killing a Giant Clam
+PlaguebringerDowned: After killing a Plaguebringer
+ReaperSharkDowned: After killing a Reaper Shark
+ColossalSquidDowned: After killing a Colossal Squid
+EidolonWyrmDowned: After killing an Eidolon Wyrm
+CloudElementalDowned: After killing a Cloud Elemental
+EarthElementalDowned: After killing an Earth Elemental
+ArmoredDiggerDowned: After killing an Armored Digger
+CragmawMireDowned: Kill a Cragmaw Mire
+MaulerDowned: Kill a Mauler
+NuclearTerrorDowned: Kill a Nuclear Terror
+GreatSandSharkDowned: Kill a Great Sand Shark
+InDeathMode: In Death Mode

--- a/Localization/en-US/Mods.FargowiltasCrossmod.Items.hjson
+++ b/Localization/en-US/Mods.FargowiltasCrossmod.Items.hjson
@@ -490,3 +490,6 @@ MolluskEnchant: {
 		Only goes on cooldown on enemy hits
 		'''
 }
+
+# This is used to detect and remove lines, not displayed. Must match Cal's localization.
+NotConsumable: Not consumable

--- a/Localization/en-US/Mods.FargowiltasCrossmod.NPCs.hjson
+++ b/Localization/en-US/Mods.FargowiltasCrossmod.NPCs.hjson
@@ -78,6 +78,22 @@ Draedon: {
 	Error: The fabric of this reality rips at the seams.
 }
 
+MutantGFBText: {
+	QuoteP2: Time to stop playing around.
+	QuoteDoG: The world is trembling..
+}
+
+ShopModSwapper: {
+	Default: Switch Mod
+	Vanilla: Vanilla
+	Calamity: Calamity mod
+}
+
+PermafrostChat: {
+	Defeat1: You clearly possess great skill! My thanks to you for freeing me, and providing an opportunity to defrost my fighting abilities.
+	Defeat2: Aah, a good round of sparring. I need the exercise, so thanks for that.
+}
+
 ThanatosRename: XM-04 Hades
 ApolloRename: XS-11 Apollo
 ExoTwinsRenameNormal: XS-01 Artemis and XS-11 Apollo

--- a/Localization/en-US/Mods.FargowiltasCrossmod.hjson
+++ b/Localization/en-US/Mods.FargowiltasCrossmod.hjson
@@ -79,3 +79,11 @@ RecipeGroups: {
 	AerospecHelmet: Aerospec Headpiece
 	StatigelHelmet: Statigel Headpiece
 }
+
+BossRushDialogue: {
+	Start: Let's get started.
+	EndP1_1: This is boring.
+	EndP1_2: Let's cut to the chase.
+}
+
+EmodeBannedByInfernum: "[c/00ffee:Eternity Mode] disabled by [c/9c0000:Infernum Mode]."

--- a/Localization/ru-RU/Mods.FargowiltasCrossmod.Conditions.hjson
+++ b/Localization/ru-RU/Mods.FargowiltasCrossmod.Conditions.hjson
@@ -1,0 +1,13 @@
+// GiantClamDowned: After killing a Giant Clam
+// PlaguebringerDowned: After killing a Plaguebringer
+// ReaperSharkDowned: After killing a Reaper Shark
+// ColossalSquidDowned: After killing a Colossal Squid
+// EidolonWyrmDowned: After killing an Eidolon Wyrm
+// CloudElementalDowned: After killing a Cloud Elemental
+// EarthElementalDowned: After killing an Earth Elemental
+// ArmoredDiggerDowned: After killing an Armored Digger
+// CragmawMireDowned: Kill a Cragmaw Mire
+// MaulerDowned: Kill a Mauler
+// NuclearTerrorDowned: Kill a Nuclear Terror
+// GreatSandSharkDowned: Kill a Great Sand Shark
+// InDeathMode: In Death Mode

--- a/Localization/ru-RU/Mods.FargowiltasCrossmod.Items.hjson
+++ b/Localization/ru-RU/Mods.FargowiltasCrossmod.Items.hjson
@@ -492,3 +492,6 @@ MolluskEnchant: {
 		Only goes on cooldown on enemy hits
 		''' */
 }
+
+# This is used to detect and remove lines, not displayed. Must match Cal's localization.
+// NotConsumable: Not consumable

--- a/Localization/ru-RU/Mods.FargowiltasCrossmod.NPCs.hjson
+++ b/Localization/ru-RU/Mods.FargowiltasCrossmod.NPCs.hjson
@@ -78,6 +78,22 @@ Draedon: {
 	// Error: The fabric of this reality rips at the seams.
 }
 
+MutantGFBText: {
+	// QuoteP2: Time to stop playing around.
+	// QuoteDoG: The world is trembling..
+}
+
+ShopModSwapper: {
+	// Default: Switch Mod
+	// Vanilla: Vanilla
+	// Calamity: Calamity mod
+}
+
+PermafrostChat: {
+	// Defeat1: You clearly possess great skill! My thanks to you for freeing me, and providing an opportunity to defrost my fighting abilities.
+	// Defeat2: Aah, a good round of sparring. I need the exercise, so thanks for that.
+}
+
 // ThanatosRename: XM-04 Hades
 // ApolloRename: XS-11 Apollo
 // ExoTwinsRenameNormal: XS-01 Artemis and XS-11 Apollo

--- a/Localization/ru-RU/Mods.FargowiltasCrossmod.hjson
+++ b/Localization/ru-RU/Mods.FargowiltasCrossmod.hjson
@@ -83,3 +83,11 @@ RecipeGroups: {
 	AerospecHelmet: шлем аэрофаза
 	StatigelHelmet: шлем статигеля
 }
+
+BossRushDialogue: {
+	// Start: Let's get started.
+	// EndP1_1: This is boring.
+	// EndP1_2: Let's cut to the chase.
+}
+
+// EmodeBannedByInfernum: "[c/00ffee:Eternity Mode] disabled by [c/9c0000:Infernum Mode]."


### PR DESCRIPTION
Moved hard coded text to licalization files. These are found by YuBell using Tiger's force localization tool.
I have tested them all, but please test them again.
This time I really learned how base summon works and deleated excess renames to calamity's NPCs. Exceptions are Profained Guardians and Anahita & Leviathan, and their names refer to Calamity's Boss Checklist integration.

Remaining problems: the default text on Devi's shop switching button. That piece of text becomes useless after clicked once, and I personally recommand a rework.