### PR TITLE
Buffed Marnite Enchant

### DIFF
--- a/Content/Calamity/Items/Accessories/Enchantments/MarniteEnchant.cs
+++ b/Content/Calamity/Items/Accessories/Enchantments/MarniteEnchant.cs
@@ -129,7 +129,10 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Accessories.Enchantments
                 {
                     addonPlayer.MarniteTimer = 0;
 
-                    int nearestNPCID = FargoSoulsUtil.FindClosestHostileNPC(player.Center, 490, true, true);
+                    bool forceEffect = player.ForceEffect<MarniteLasersEffect>();
+                    int detectionRange = forceEffect ? 930 : 490;
+
+                    int nearestNPCID = FargoSoulsUtil.FindClosestHostileNPC(player.Center, detectionRange, true, true);
                     if (nearestNPCID.IsWithinBounds(Main.maxNPCs))
                     {
                         NPC nearestNPC = Main.npc[nearestNPCID];
@@ -138,7 +141,8 @@ namespace FargowiltasCrossmod.Content.Calamity.Items.Accessories.Enchantments
                             Vector2 pos = Main.rand.NextVector2FromRectangle(player.Hitbox);
                             Vector2 vel = pos.DirectionTo(nearestNPC.Center) * 2;
 
-                            float damage = player.ForceEffect<MarniteLasersEffect>() ? 150 : 30;
+                            float damage = player.ForceEffect<MarniteLasersEffect>() ? 80 : 30;
+                            damage *= player.ActualClassDamage(DamageClass.Generic);
 
                             int index = Projectile.NewProjectile(player.GetSource_EffectItem<MarniteLasersEffect>(), pos, vel, ModContent.ProjectileType<MarniteLaser>(), (int)damage, 1, player.whoAmI);
                             if (index.IsWithinBounds(Main.maxProjectiles) && Main.projectile[index] is Projectile proj)

--- a/Content/Calamity/Projectiles/MarniteDagger.cs
+++ b/Content/Calamity/Projectiles/MarniteDagger.cs
@@ -35,7 +35,7 @@ namespace FargowiltasCrossmod.Content.Calamity.Projectiles
             Projectile.hostile = false;
             ProjectileID.Sets.CultistIsResistantTo[Type] = true;
             Projectile.tileCollide = false;
-            Projectile.timeLeft = 240;
+            Projectile.timeLeft = 480;
             Projectile.scale = 0.7f;
             Projectile.width = Projectile.height = 8;
             ProjectileID.Sets.TrailingMode[Type] = 2;


### PR DESCRIPTION
Proximity laser now scales with generic damage bonuses
Wizard prox. laser base damage = 80
Wizard now nearly doubles proximity range