### PR TITLE
fix worm boss multiplayer bug (packet overload + Aquatic Scourge Eternity AI fix)

### DIFF
--- a/Content/Calamity/Bosses/AquaticScourge/ASEternity.cs
+++ b/Content/Calamity/Bosses/AquaticScourge/ASEternity.cs
@@ -332,10 +332,19 @@ namespace FargowiltasCrossmod.Content.Calamity.Bosses.AquaticScourge
                 }
                 if (npc.ai[2] == -1)
                 {
-                    if (DLCUtils.HostCheck)
+                    if (Main.netMode == NetmodeID.SinglePlayer) //for singleplayer
+                    {
                         npc.StrikeInstantKill();
-                    //else
-                    //    npc.active = false;
+                    }
+                    else if (Main.netMode == NetmodeID.Server) //for multiplayer
+                    {
+                        npc.life = 0;
+                        npc.HitEffect();
+                        npc.checkDead();
+                        npc.active = false;
+                        npc.netUpdate = true;
+                        NetMessage.SendData(MessageID.SyncNPC, -1, -1, null, npc.whoAmI);
+                    }
                     return false;
                 }
                 NPC head = Main.npc[(int)npc.ai[2]];

--- a/Core/Calamity/Globals/CalDLCNPCChanges.cs
+++ b/Core/Calamity/Globals/CalDLCNPCChanges.cs
@@ -1667,11 +1667,6 @@ namespace FargowiltasCrossmod.Core.Calamity.Globals
             {
                 Mod calamity = ModCompatibility.Calamity.Mod;
 
-                if (npc.Calamity().newAI[1] == 0f) //SyncExtraAI immediately after spawn
-                {
-                    npc.SyncExtraAI();
-                }
-
                 calamity.Call("SetCalamityAI", npc, 1, 600f); //DRIncreaseTime in Calamity Destroyer and Calamity EoW - fix destroyer invincible bug
                 calamity.Call("SetCalamityAI", npc, 2, 0f);
 

--- a/Core/Calamity/Globals/CalDLCNPCChanges.cs
+++ b/Core/Calamity/Globals/CalDLCNPCChanges.cs
@@ -1657,27 +1657,47 @@ namespace FargowiltasCrossmod.Core.Calamity.Globals
             {
                 npc.dontTakeDamage = true;
             }
-            //make destroyer not invincible and normal scale
-            List<int> bossworms =
+            //make destroyer not invincible and revamp calamity scale change
+            List<int> vanillabossworms =
                 [
-
-                    ModContent.NPCType<DesertScourgeHead>(), ModContent.NPCType<DesertScourgeBody>(), ModContent.NPCType<DesertScourgeTail>(),
                     NPCID.EaterofWorldsHead, NPCID.EaterofWorldsBody, NPCID.EaterofWorldsTail,
-
-                    ModContent.NPCType<AquaticScourgeHead>(), ModContent.NPCType<AquaticScourgeBody>(),ModContent.NPCType<AquaticScourgeBodyAlt>(), ModContent.NPCType<AquaticScourgeTail>(),
                     NPCID.TheDestroyer, NPCID.TheDestroyerBody, NPCID.TheDestroyerTail,
-                    /*ModContent.NPCType<AstrumDeusHead>(), ModContent.NPCType<AstrumDeusBody>(), ModContent.NPCType<AstrumDeusTail>(),*/
-                    ModContent.NPCType<StormWeaverHead>(), ModContent.NPCType<StormWeaverBody>(), ModContent.NPCType<StormWeaverTail>(),
-
                 ];
-            if (bossworms.Contains(npc.type) && WorldSavingSystem.EternityMode)
+            if (vanillabossworms.Contains(npc.type) && WorldSavingSystem.EternityMode)
             {
                 Mod calamity = ModCompatibility.Calamity.Mod;
 
-                calamity.Call("SetCalamityAI", npc, 1, 600f);
+                if (npc.Calamity().newAI[1] == 0f) //SyncExtraAI immediately after spawn
+                {
+                    npc.SyncExtraAI();
+                }
+
+                calamity.Call("SetCalamityAI", npc, 1, 600f); //DRIncreaseTime in Calamity Destroyer and Calamity EoW - fix destroyer invincible bug
                 calamity.Call("SetCalamityAI", npc, 2, 0f);
-                npc.SyncExtraAI();
+
+                if (Main.GameUpdateCount % 20 == 0 && Main.netMode != NetmodeID.MultiplayerClient) //when not limited, SUPER LAGGY and cause multiplayer desync issue
+                {
+                    npc.SyncExtraAI();
+                }
             }
+            /*List<int> calamitybossworms =
+                [
+                    ModContent.NPCType<DesertScourgeHead>(), ModContent.NPCType<DesertScourgeBody>(), ModContent.NPCType<DesertScourgeTail>(),
+                    //ModContent.NPCType<AquaticScourgeHead>(), ModContent.NPCType<AquaticScourgeBody>(), ModContent.NPCType<AquaticScourgeBodyAlt>(), ModContent.NPCType<AquaticScourgeTail>(),
+                    //ModContent.NPCType<AstrumDeusHead>(), ModContent.NPCType<AstrumDeusBody>(), ModContent.NPCType<AstrumDeusTail>(),
+                    //ModContent.NPCType<StormWeaverHead>(), ModContent.NPCType<StormWeaverBody>(), ModContent.NPCType<StormWeaverTail>(),
+                ];
+            if (calamitybossworms.Contains(npc.type) && WorldSavingSystem.EternityMode)
+            {
+                //Mod calamity = ModCompatibility.Calamity.Mod;
+                //calamity.Call("SetCalamityAI", npc, 1, 600f);
+                //calamity.Call("SetCalamityAI", npc, 2, 0f);
+
+                if (Main.GameUpdateCount % 20 == 0 && Main.netMode != NetmodeID.MultiplayerClient)
+                {
+                    npc.SyncExtraAI();
+                }
+            }*/
             //make plantera not summon free tentacles
             if (npc.type == ModContent.NPCType<PlanterasFreeTentacle>())
             {


### PR DESCRIPTION
1. separate `bossworms` into `vanillabossworms`(EoW, Destroyer) and `calamitybossworms`(Desert Scourge, Aquatic Scourge, Storm Weaver)
2. limit SyncExtraAI calls (per 20 frames) to prevent packet overload for multiplayer - without this, almost every boss in `bossworms` list becomes unplayable in multiplayer, so I added a limit
3. remove SetCalamityAI for wrong boss
4. remove `SyncExtraAI` for EVERY `calamitybossworms`

I tested every worm boss to check which bosses actually need `SyncExtraAI` - and calamity worms don't need/issue isnt fixed with this code (even Desert Scourge, Aquatic Scourge that have their own eternity AI).

* Desert Scourge - it didn't need SyncExtraAI. they already have their own sync process in Eternity AI (a has very little body/head separation but minor problem. and when turn on SyncExtraAI to DS, they have a high chance to print WARN log `System.IO.EndOfStreamException: Unable to read beyond the end of the stream.` from tmodloader. so I think remove SyncExtraAI for DS is much better)
* Aquatic Scourge - this one has unplayable bug but not fixed by SyncExtraAI (per 20 frames); aquatic scourge body (include only-hittable body parts) disappear at specific point (when Hittable body segment changes cause Aquatic Scourge's HP)
* Storm Weaver - whether SyncExtraAI exist or not, they have some multiplayer bug like their head goes back periodic (still playable)
* Astrum Deus - already removed by someone else*

may have better solution, but for now this is the best for now for temporary multiplayer fix (except aquatic scourge) I think.
:)